### PR TITLE
fix: allow missing ref.toml by falling back to environment defaults

### DIFF
--- a/backend/src/ref_backend/core/ref.py
+++ b/backend/src/ref_backend/core/ref.py
@@ -13,10 +13,11 @@ def get_ref_config(settings: Settings) -> Config:
     Get the REF configuration object
     """
     config_fname = Path(settings.REF_CONFIGURATION) / "ref.toml"
-    if not config_fname.exists():
-        raise FileNotFoundError(f"REF configuration file not found: {config_fname}")
-    logger.info(f"Loading REF configuration from {config_fname}")
-    return Config.load(config_fname)
+    if config_fname.exists():
+        logger.info(f"Loading REF configuration from {config_fname}")
+    else:
+        logger.info(f"REF configuration file not found at {config_fname}, using defaults")
+    return Config.load(config_fname, allow_missing=True)
 
 
 def get_database(ref_config: Config) -> Database:

--- a/backend/tests/test_core/test_ref.py
+++ b/backend/tests/test_core/test_ref.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from climate_ref.config import Config
+from ref_backend.core.config import Settings
+from ref_backend.core.ref import get_ref_config
+
+
+def test_get_ref_config_missing_toml(tmp_path: Path):
+    """get_ref_config returns a default Config when ref.toml does not exist"""
+    settings = Settings(REF_CONFIGURATION=str(tmp_path))
+
+    config = get_ref_config(settings)
+
+    assert isinstance(config, Config)
+
+
+def test_get_ref_config_with_toml(tmp_path: Path):
+    """get_ref_config loads configuration from ref.toml when it exists"""
+    toml_file = tmp_path / "ref.toml"
+    toml_file.write_text("")
+
+    settings = Settings(REF_CONFIGURATION=str(tmp_path))
+
+    config = get_ref_config(settings)
+
+    assert isinstance(config, Config)

--- a/changelog/26.fix.md
+++ b/changelog/26.fix.md
@@ -1,0 +1,1 @@
+Allowed the application to start without a `ref.toml` file by falling back to environment defaults.


### PR DESCRIPTION
Previously `get_ref_config` raised `FileNotFoundError` when `ref.toml` was absent. Now falls back to environment defaults using `Config.load(allow_missing=True)`, matching the rest of the application.

Adds tests for both missing and present `ref.toml` cases.