### PR TITLE
chore: Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -24,13 +24,13 @@ jobs:
       CI_COMMIT_EMAIL: "ci-runner@climate-ref.invalid"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get changed changelog files
         id: changed-changelog-files
         uses: tj-actions/changed-files@v47
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
       with:
         version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -20,14 +20,14 @@ jobs:
     name: climate-ref-frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: metadata
         with:
           images: ghcr.io/${{ github.repository_owner }}/climate-ref-frontend
@@ -36,7 +36,7 @@ jobs:
             type=ref,event=tag
             # set latest tag for default branch
             type=raw,value=main,enable={{is_default_branch}}
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v7
         id: push
         with:
           cache-from: type=gha
@@ -48,7 +48,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
       - name: Attest to climate-ref-frontend image
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         if: ${{ ! github.event.pull_request.head.repo.fork }}
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/climate-ref-frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Release Draft
         uses: softprops/action-gh-release@v2

--- a/changelog/27.trivial.md
+++ b/changelog/27.trivial.md
@@ -1,0 +1,1 @@
+Updated GitHub Actions to Node.js 24 compatible versions ahead of the Node.js 20 deprecation.


### PR DESCRIPTION
## Summary

- Update all GitHub Actions to versions that support Node.js 24, resolving deprecation warnings for Node.js 20
- Affected workflows: `ci.yml`, `containers.yaml`, `bump.yaml`, `release.yaml`

### Updated actions

| Action | Previous | Updated |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `astral-sh/setup-uv` | v6 | v8 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v4 | v7 |
| `actions/attest-build-provenance` | v2 | v4 |

## Test plan

- [ ] CI workflow passes on this PR
- [ ] Container build workflow passes