### PR TITLE
fix(pre-commit): type-check with tsc -b so build errors are caught

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
       # Frontend: TypeScript typecheck
       - id: typescript-typecheck
         name: TypeScript typecheck
-        entry: bash -lc "cd frontend && npx --yes tsc --noEmit"
+        entry: bash -lc "cd frontend && npx --yes tsc -b --noEmit"
         language: system
         pass_filenames: false
         files: ^frontend/

--- a/changelog/33.trivial.md
+++ b/changelog/33.trivial.md
@@ -1,0 +1,1 @@
+Corrected the pre-commit TypeScript check to use project-reference build mode (`tsc -b`), so build-breaking type errors are caught before they reach CI.


### PR DESCRIPTION
## Summary

The pre-commit `TypeScript typecheck` hook ran `tsc --noEmit`, but the root `frontend/tsconfig.json` is solution-style (`"files": []`, only project `references`). Plain `tsc --noEmit` resolves to that root config and type-checks **zero** files under `src/`, so a build-breaking type error passes the gate — locally and in CI — and only surfaces in the real build (`tsc -b && vite build`).

This switches the hook to `tsc -b --noEmit` (project-reference build mode, no emit), which descends into the referenced projects (`tsconfig.app.json` / `tsconfig.node.json`) exactly as the build does.

```diff
-        entry: bash -lc "cd frontend && npx --yes tsc --noEmit"
+        entry: bash -lc "cd frontend && npx --yes tsc -b --noEmit"
```

## Verification

Ran in `frontend/` (with deps installed) using a throwaway `src/` probe with a `string | null | undefined` → `string | undefined` mismatch:

| Command | Clean tree | Deliberate type error |
|---|---|---|
| `tsc --noEmit` (old) | exit 0 | **exit 0** — false negative, error missed |
| `tsc -b --noEmit` (new) | exit 0 | **exit 2** — `error TS2322: Type 'null' is not assignable to type 'string \| undefined'` |

Probe removed afterward; clean tree passes again. TypeScript is 5.8.3, so `-b --noEmit` is supported (added in 5.6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pre-commit TypeScript check so type issues are detected earlier and more reliably before code reaches CI.

* **Chores**
  * Updated the changelog with a note about the TypeScript check improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->