### PR TITLE
chore: add Renovate for frontend and backend dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/changelog/34.trivial.md
+++ b/changelog/34.trivial.md
@@ -1,0 +1,1 @@
+Added Renovate to automatically keep the frontend and backend dependencies up to date, wired into vulnerability alerts with a 3-day release-age standdown as a supply-chain safeguard.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "timezone": "Pacific/Auckland",
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"]
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Label frontend (npm) updates",
+      "matchManagers": ["npm"],
+      "addLabels": ["frontend"]
+    },
+    {
+      "description": "Label backend (uv / Python) updates",
+      "matchManagers": ["pep621"],
+      "addLabels": ["backend"]
+    },
+    {
+      "description": "Group non-major frontend updates into a single PR",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "frontend non-major"
+    },
+    {
+      "description": "Group non-major backend updates into a single PR",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "backend non-major"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
-  "timezone": "Pacific/Auckland",
+  "timezone": "Australia/Melbourne",
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",
   "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Summary

Adds [Renovate](https://docs.renovatebot.com/) to keep both the frontend (npm) and backend (uv / `pep621`) dependencies up to date, wired into GitHub's Dependabot/Advisory vulnerability alerts, with a 3-day release-age standdown as a supply-chain safeguard.

## What's included

- **`renovate.json`**
  - Manages both **npm** (frontend, `package-lock.json`) and **pep621** (backend, `uv.lock`) — Renovate updates both lockfiles natively.
  - `minimumReleaseAge: "3 days"` applied globally so it covers both npm and uv, with `internalChecksFilter: "strict"` so PRs are held back until a release is 3 days old rather than opened immediately. This is the standdown against freshly-published malicious/compromised releases.
  - `vulnerabilityAlerts` reads GitHub's Dependabot alerts, plus `osvVulnerabilityAlerts` for OSV coverage.
  - Non-major updates grouped per ecosystem (`frontend non-major` / `backend non-major`) to reduce noise; majors stay separate. Weekly `lockFileMaintenance`, labels, and a dependency dashboard.
- **`.github/workflows/ci.yml`** — extends the `check-changelog` guard to also skip `renovate[bot]` (it already skips `dependabot[bot]`). Without this, every Renovate PR would fail CI on the missing-changelog gate.

## Follow-up required (repo settings, not in this PR)

- Install/enable the **Renovate GitHub App** on the repo — it won't act until onboarded.
- Enable **Dependency graph** + **Dependabot alerts** under repo Settings so `vulnerabilityAlerts` has a data source.

## Note on the standdown vs. security fixes

The 3-day standdown currently also applies to vulnerability-alert PRs (conservative, supply-chain-first). If you'd prefer security fixes to bypass the wait, set `minimumReleaseAge: "0"` inside the `vulnerabilityAlerts` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dependency update management, including grouped non-major updates and a dashboard for tracking pending updates.
  * Enabled vulnerability alerts with a short release-age safeguard before updates are released.
* **Chores**
  * Updated CI checks so automated dependency update pull requests no longer trigger changelog validation unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->