### PR TITLE
Give each request its own database session

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "psycopg[binary]<4.0.0,>=3.1.13",
     "pydantic-settings<3.0.0,>=2.13.1",
     "sentry-sdk[fastapi]>=2.0.0",
-    "climate-ref[aft-providers,postgres]>=0.17.0,<0.18",
+    "climate-ref[aft-providers,postgres]>=0.17.2,<0.18",
     "loguru",
     "pyyaml>=6.0",
     "fastapi-sqlalchemy-monitor>=1.1.3",

--- a/backend/src/ref_backend/api/deps.py
+++ b/backend/src/ref_backend/api/deps.py
@@ -44,27 +44,24 @@ DatabaseDep = Annotated[Database, Depends(_get_database_dependency)]
 
 def get_database_session(database: DatabaseDep) -> Generator[Session, None, None]:
     """
-    Provide the database session for the duration of a request
+    Provide a session that lives for the duration of a request
 
-    A Database owns a single Session, so this session is shared process-wide rather than
-    isolated per request.
-    SQLAlchemy opens a transaction on first use and holds it until the session is closed,
-    so closing on the way out returns the connection to the pool.
+    `Database.session` is long lived and shared process-wide, so it is not safe to hand to a
+    request. `session_scope` gives each request its own session on the shared engine and pool,
+    and closes it once the response is sent.
     """
-    try:
-        yield database.session
-    finally:
-        database.session.close()
+    with database.session_scope() as session:
+        yield session
 
 
 SessionDep = Annotated[Session, Depends(get_database_session)]
 
 
-def _get_reader_dependency(database: DatabaseDep, ref_config: REFConfigDep) -> Reader:
+def _get_reader_dependency(database: DatabaseDep, ref_config: REFConfigDep, session: SessionDep) -> Reader:
     """
     Get the results reader
     """
-    return Reader(database, results=ref_config.paths.results)
+    return Reader(database, results=ref_config.paths.results, session=session)
 
 
 ReaderDep = Annotated[Reader, Depends(_get_reader_dependency)]

--- a/backend/src/ref_backend/api/deps.py
+++ b/backend/src/ref_backend/api/deps.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from dataclasses import dataclass
+from threading import Lock
 from typing import Annotated
 
 from fastapi import Depends
@@ -25,8 +26,17 @@ def _ref_config_dependency(settings: SettingsDep) -> Config:
 REFConfigDep = Annotated[Config, Depends(_ref_config_dependency)]
 
 
+_database_cache: dict[tuple[str, bool], Database] = {}
+_database_cache_lock = Lock()
+
+
 def _get_database_dependency(settings: SettingsDep, ref_config: REFConfigDep) -> Database:
-    return get_database(ref_config, read_only=settings.REF_READ_ONLY_DATABASE)
+    # A Database owns an engine and its connection pool, so it is reused across requests.
+    key = (ref_config.db.database_url, settings.REF_READ_ONLY_DATABASE)
+    with _database_cache_lock:
+        if key not in _database_cache:
+            _database_cache[key] = get_database(ref_config, read_only=settings.REF_READ_ONLY_DATABASE)
+        return _database_cache[key]
 
 
 DatabaseDep = Annotated[Database, Depends(_get_database_dependency)]
@@ -34,9 +44,16 @@ DatabaseDep = Annotated[Database, Depends(_get_database_dependency)]
 
 def get_database_session(database: DatabaseDep) -> Generator[Session, None, None]:
     """
-    Create a new database session
+    Provide the database session for the duration of a request
+
+    SQLAlchemy opens a transaction on first use and holds it until the session is closed.
+    Closing on the way out returns the connection to the pool, so it does not sit idle
+    in a transaction until the server or the database times it out.
     """
-    yield database.session
+    try:
+        yield database.session
+    finally:
+        database.session.close()
 
 
 SessionDep = Annotated[Session, Depends(get_database_session)]

--- a/backend/src/ref_backend/api/deps.py
+++ b/backend/src/ref_backend/api/deps.py
@@ -46,9 +46,10 @@ def get_database_session(database: DatabaseDep) -> Generator[Session, None, None
     """
     Provide the database session for the duration of a request
 
-    SQLAlchemy opens a transaction on first use and holds it until the session is closed.
-    Closing on the way out returns the connection to the pool, so it does not sit idle
-    in a transaction until the server or the database times it out.
+    A Database owns a single Session, so this session is shared process-wide rather than
+    isolated per request.
+    SQLAlchemy opens a transaction on first use and holds it until the session is closed,
+    so closing on the way out returns the connection to the pool.
     """
     try:
         yield database.session

--- a/backend/src/ref_backend/main.py
+++ b/backend/src/ref_backend/main.py
@@ -10,7 +10,6 @@ from fastapi.exception_handlers import (
 from loguru import logger
 
 from climate_ref.config import Config as RefConfig
-from climate_ref.database import Database
 from climate_ref.provider_registry import ProviderRegistry
 from ref_backend.api import deps
 from ref_backend.core.config import get_settings
@@ -24,11 +23,11 @@ dotenv.load_dotenv(override=True)
 settings = get_settings()
 
 from ref_backend.builder import build_app  # noqa: E402
-from ref_backend.core.ref import get_database, get_provider_registry, get_ref_config  # noqa: E402
+from ref_backend.core.ref import get_provider_registry, get_ref_config  # noqa: E402
 
 # Initialize singletons at application startup
 ref_config = get_ref_config(settings)
-database = get_database(ref_config, read_only=settings.REF_READ_ONLY_DATABASE)
+database = deps._get_database_dependency(settings, ref_config)
 provider_registry = get_provider_registry(ref_config, read_only=settings.REF_READ_ONLY_DATABASE)
 
 setup_logging(settings.LOG_LEVEL)
@@ -40,16 +39,11 @@ def get_singleton_config() -> RefConfig:
     return ref_config
 
 
-def get_singleton_database() -> Database:
-    return database
-
-
 def get_singleton_provider_registry() -> ProviderRegistry:
     return provider_registry
 
 
 app.dependency_overrides[deps._ref_config_dependency] = get_singleton_config
-app.dependency_overrides[deps._get_database_dependency] = get_singleton_database
 app.dependency_overrides[deps._provider_registry_dependency] = get_singleton_provider_registry
 
 if settings.USE_TEST_DATA:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,6 @@ from starlette.testclient import TestClient
 from ref_backend.api import deps
 from ref_backend.builder import build_app
 from ref_backend.core.config import get_settings
-from ref_backend.core.ref import get_database
 from ref_backend.testing import test_ref_config, test_settings
 
 
@@ -25,7 +24,9 @@ def app() -> FastAPI:
     including mocking Sentry setup and using a custom settings function.
     """
     app = build_app(
-        settings=test_settings(), ref_config=test_ref_config(), database=get_database(test_ref_config())
+        settings=test_settings(),
+        ref_config=test_ref_config(),
+        database=deps._get_database_dependency(test_settings(), test_ref_config()),
     )
 
     app.dependency_overrides[get_settings] = test_settings

--- a/backend/tests/test_api/test_deps.py
+++ b/backend/tests/test_api/test_deps.py
@@ -1,0 +1,39 @@
+import pytest
+import sqlalchemy
+from fastapi.testclient import TestClient
+
+from ref_backend.api.deps import _get_database_dependency, get_database_session
+from ref_backend.testing import test_ref_config as _load_test_ref_config
+
+
+def test_database_dependency_is_reused(settings):
+    """The same Database, and so the same engine, is handed to every request"""
+    first = _get_database_dependency(settings, _load_test_ref_config())
+    second = _get_database_dependency(settings, _load_test_ref_config())
+
+    assert first is second
+
+
+def test_session_dependency_closes_the_transaction(settings):
+    """The session dependency ends the transaction once the request is done"""
+    database = _get_database_dependency(settings, _load_test_ref_config())
+
+    generator = get_database_session(database)
+    session = next(generator)
+    session.execute(sqlalchemy.text("SELECT 1"))
+    assert session.in_transaction()
+
+    with pytest.raises(StopIteration):
+        next(generator)
+
+    assert not session.in_transaction()
+
+
+def test_request_leaves_no_open_transaction(client: TestClient, settings):
+    """A completed request does not leave a connection idle in a transaction"""
+    database = _get_database_dependency(settings, _load_test_ref_config())
+
+    response = client.get(f"{settings.API_V1_STR}/diagnostics/")
+
+    assert response.status_code == 200
+    assert not database.session.in_transaction()

--- a/backend/tests/test_api/test_deps.py
+++ b/backend/tests/test_api/test_deps.py
@@ -1,9 +1,13 @@
-import pytest
+from contextlib import contextmanager
+
 import sqlalchemy
 from fastapi.testclient import TestClient
 
 from ref_backend.api.deps import _get_database_dependency, get_database_session
 from ref_backend.testing import test_ref_config as _load_test_ref_config
+
+# FastAPI drives the dependency as a generator, so the tests wrap it to get the same teardown.
+session_scope = contextmanager(get_database_session)
 
 
 def test_database_dependency_is_reused(settings):
@@ -14,26 +18,32 @@ def test_database_dependency_is_reused(settings):
     assert first is second
 
 
+def test_session_dependency_is_request_scoped(settings):
+    """Each request gets its own session rather than the shared long-lived one"""
+    database = _get_database_dependency(settings, _load_test_ref_config())
+
+    with session_scope(database) as first, session_scope(database) as second:
+        assert first is not second
+        assert first is not database.session
+        assert second is not database.session
+
+
 def test_session_dependency_closes_the_transaction(settings):
     """The session dependency ends the transaction once the request is done"""
     database = _get_database_dependency(settings, _load_test_ref_config())
 
-    generator = get_database_session(database)
-    session = next(generator)
-    session.execute(sqlalchemy.text("SELECT 1"))
-    assert session.in_transaction()
-
-    with pytest.raises(StopIteration):
-        next(generator)
+    with session_scope(database) as session:
+        session.execute(sqlalchemy.text("SELECT 1"))
+        assert session.in_transaction()
 
     assert not session.in_transaction()
 
 
-def test_request_leaves_no_open_transaction(client: TestClient, settings):
-    """A completed request does not leave a connection idle in a transaction"""
+def test_request_returns_its_connection_to_the_pool(client: TestClient, settings):
+    """A completed request does not leave a connection checked out"""
     database = _get_database_dependency(settings, _load_test_ref_config())
 
     response = client.get(f"{settings.API_V1_STR}/diagnostics/")
 
     assert response.status_code == 200
-    assert not database.session.in_transaction()
+    assert database._engine.pool.checkedout() == 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "climate-ref"
-version = "0.17.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -380,9 +380,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b5/60feaeabd2b60188b15919f2e701edc3ca5954f187a2669483616c77547e/climate_ref-0.17.0.tar.gz", hash = "sha256:863082f687996cf3f54beea5af8f48093a84ac56b1b16769d05ac30fc1483b4d", size = 491876, upload-time = "2026-08-13T00:13:11.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a5/cd91150b45b4ad5caa6cca711a80796853a600614891b607ccd419996367/climate_ref-0.17.2.tar.gz", hash = "sha256:f622747f99ec7afa427d9111eada09fc3e0ed0decc54a257237818c1bebd4e09", size = 515434, upload-time = "2026-08-14T03:48:16.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/38/aa56577f5c37250e0a76db55a538b7f684c54310d7656de75f6bb2672aab/climate_ref-0.17.0-py3-none-any.whl", hash = "sha256:d87bb640d2e3bca52d2f9731696cc14a368543433353a63d7fb54c5bf667182f", size = 299420, upload-time = "2026-08-13T00:13:09.703Z" },
+    { url = "https://files.pythonhosted.org/packages/74/99/2e035c4e2eccf984e60f30a0503379e7dc02f8140c0d514496f3572f9668/climate_ref-0.17.2-py3-none-any.whl", hash = "sha256:4738d9102580942a68de0c5e016786391df565879f420975bd153de68164c373", size = 317996, upload-time = "2026-08-14T03:48:11.841Z" },
 ]
 
 [package.optional-dependencies]
@@ -398,7 +398,7 @@ postgres = [
 
 [[package]]
 name = "climate-ref-core"
-version = "0.17.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -419,14 +419,14 @@ dependencies = [
     { name = "setuptools" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/9c/4e5f29f6821c1a36ce66cbcdd3b2c5f9e4f53cf6a0e1d08407944f219fb4/climate_ref_core-0.17.0.tar.gz", hash = "sha256:9e626a1f24df269fe2e6109db4baa3751c87bf639900b58e3bd6d9f9671b2e6b", size = 210418, upload-time = "2026-08-13T00:13:00.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/e3/32d181de168753915863559353cb5707f0de87d7454e057b519b0f489d40/climate_ref_core-0.17.2.tar.gz", hash = "sha256:984753038ed1bd7595ee1422157c72b46fbf495a7c78448cffff771165207f58", size = 217958, upload-time = "2026-08-14T03:48:24.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/13/48d951bd8ad06f7b58d43089c016a9d1fd056f976279d8b92914c475f31a/climate_ref_core-0.17.0-py3-none-any.whl", hash = "sha256:1cc88dd2da0797e95c919ce640537dabd85f38e23b383708da5ff40e8ad0cc95", size = 142777, upload-time = "2026-08-13T00:12:58.464Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/03/60eab0429deee75115d5572c5b4107e77ef3841885bd40b4ac2e12dffa86/climate_ref_core-0.17.2-py3-none-any.whl", hash = "sha256:50574f7b910e004fe3fbae475228ecc5c599f7a40fa01a7a2bca0b4f3adbdb6d", size = 147428, upload-time = "2026-08-14T03:48:18.709Z" },
 ]
 
 [[package]]
 name = "climate-ref-esmvaltool"
-version = "0.17.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cftime" },
@@ -436,34 +436,34 @@ dependencies = [
     { name = "pyyaml" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ce/2c117d54f539311ba2f13bd94a884a84a5c09a96dcec729cb02373810fbc/climate_ref_esmvaltool-0.17.0.tar.gz", hash = "sha256:1c4a82af69222a1039c634757dbaaba1d6ef012f77473a04fee750e2a4f0ed7a", size = 514868, upload-time = "2026-08-13T00:12:59.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/15/1f202be21e1958fe0fe7dbc42e2913d2812cd6ee30cbabfb7f63e983af80/climate_ref_esmvaltool-0.17.2.tar.gz", hash = "sha256:c9732c963a776638c1c0f3b5a40e1f85d83c62d2dd5c8b6c5fc106ece8ea4458", size = 514881, upload-time = "2026-08-14T03:48:14.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/41/4aec3c6175014543bfa25283610e7d31b62e3d07c46cd42a0957290508e1/climate_ref_esmvaltool-0.17.0-py3-none-any.whl", hash = "sha256:1682942ff32aeea6efe5d30183ae930caa89e849062cb393d7c315b057f11486", size = 169922, upload-time = "2026-08-13T00:13:02.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/921351a00a1ac60e24005bf4bfdd06a79df8b6e6bceb3381bc9f20440b79/climate_ref_esmvaltool-0.17.2-py3-none-any.whl", hash = "sha256:168c8d5f4cdac58c4e9d6779763779b501ecdadfcf3a27dc6c847735c901a87a", size = 169922, upload-time = "2026-08-14T03:48:12.977Z" },
 ]
 
 [[package]]
 name = "climate-ref-ilamb"
-version = "0.17.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "climate-ref-core" },
     { name = "ilamb3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/3a/533ecbebf3ab9cc0e8caf5c6e99cd8f32d8cd47a1cb6cfc15c68f2aeffbb/climate_ref_ilamb-0.17.0.tar.gz", hash = "sha256:8737e63321534ea10c92f9e8c6cff05e18dcab0b2c037976cc3a9e6eff0f474d", size = 246081, upload-time = "2026-08-13T00:13:05.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2e/dd14d5d015c91a93e39d353df2f069badbc5842562bd277ed1dce10793bb/climate_ref_ilamb-0.17.2.tar.gz", hash = "sha256:9c17326071b31c5dd406f9fba80f294d9af0f37f44a3b33574874b6f43e7c046", size = 246080, upload-time = "2026-08-14T03:48:20.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ef/273a25d452edd3025bd65063cc18ed836a1f5870c9547660efd5cb0f3a4e/climate_ref_ilamb-0.17.0-py3-none-any.whl", hash = "sha256:5f2572a75efd418e608e5ed12a70eedd052694e4c101120d840954ff04a18e4f", size = 26054, upload-time = "2026-08-13T00:13:07.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/58/54712a2e88198009b7ffeac394001853b02451ab527110fc9d1b8112c765/climate_ref_ilamb-0.17.2-py3-none-any.whl", hash = "sha256:6c303f50dd88099128c30cc2eebcaf48ceb25718bae5f7897f2d16047741787e", size = 26055, upload-time = "2026-08-14T03:48:19.825Z" },
 ]
 
 [[package]]
 name = "climate-ref-pmp"
-version = "0.17.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "climate-ref-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/af/9c690901183282d6a5ceffd0e91486e403f345d05b173e2fe30e64afff1e/climate_ref_pmp-0.17.0.tar.gz", hash = "sha256:8bc2006584b1fba3175fa9f837ac7d3476df6b9e21f2c47c90551bda0b5ce430", size = 1323765, upload-time = "2026-08-13T00:13:06.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/75/748223c9d8bd1bf92252e58f12be4b0bec1cadfa7cf19553734720fa7e4a/climate_ref_pmp-0.17.2.tar.gz", hash = "sha256:7ae3003a52e95dda4360136d48303c69f4a9eec59bf2e20a82aa2c67dea985d9", size = 1323759, upload-time = "2026-08-14T03:48:22.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/24/386527ddb55b118cceeb496849fb452323e664927ee0d45dec229e85218b/climate_ref_pmp-0.17.0-py3-none-any.whl", hash = "sha256:353786683b6e387a5fb3619f449a0e679203f26a5e34e16f08b875ecb4fa05b6", size = 100088, upload-time = "2026-08-13T00:13:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/40/17/a1dd47b6079f249c260379246d698570c82f38c5be008c7699ae26b343c2/climate_ref_pmp-0.17.2-py3-none-any.whl", hash = "sha256:60a447c4a6f304c9dacbe2f751ccbb46aacbce70b2c2b04736ef3a3f5609603e", size = 100088, upload-time = "2026-08-14T03:48:23.563Z" },
 ]
 
 [[package]]
@@ -2661,7 +2661,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "climate-ref", extras = ["aft-providers", "postgres"], specifier = ">=0.17.0,<0.18" },
+    { name = "climate-ref", extras = ["aft-providers", "postgres"], specifier = ">=0.17.2,<0.18" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.114.2,<1.0.0" },
     { name = "fastapi-sqlalchemy-monitor", specifier = ">=1.1.3" },
     { name = "loguru" },

--- a/changelog/51.fix.md
+++ b/changelog/51.fix.md
@@ -1,3 +1,4 @@
-Closes the database session once a request finishes.
-The session dependency had no teardown, so every request left a connection idle in a transaction.
-The `Database` is also now cached per url, rather than being rebuilt on each request.
+Gives each request its own database session, so a request no longer leaves a connection idle in a transaction.
+The session dependency handed out `Database.session`, which is long lived and shared process-wide, and never closed it.
+This now uses `Database.session_scope` from climate-ref 0.17.2, which is the minimum version as a result.
+The `Database` is also cached per url, rather than being rebuilt on each request.

--- a/changelog/51.fix.md
+++ b/changelog/51.fix.md
@@ -1,0 +1,3 @@
+Closes the database session once a request finishes.
+The session dependency had no teardown, so every request left a connection idle in a transaction.
+The `Database` is also now cached per url, rather than being rebuilt on each request.


### PR DESCRIPTION
Fixes connections left idle in a transaction.

`get_database_session` yielded `database.session` with nothing after the `yield`. FastAPI runs generator teardown after each response, but there was no teardown, so the transaction SQLAlchemy opens on first use never ended. Each request left a connection idle in a transaction until the server or the database timed it out. The CNPG timeout is a backstop, not the cure.

Closing that session on the way out is not enough on its own. `Database` owns a single long-lived `Session` and every request shares it, so a teardown that closes it can end a transaction another in-flight request is still using. All of the routes here are `async def`, so two requests really can be in flight at once.

- Uses `Database.session_scope` from climate-ref 0.17.2, so each request gets its own session. The engine and its connection pool stay shared, so only the session is private to the request.
- Passes that session to the `Reader`, so a request reads through one session throughout rather than mixing the request session with the shared one.
- Caches the `Database` per url and read-only flag. `_get_database_dependency` called `Database.from_config` fresh on every request, so each read built an engine and a session and abandoned both. `main.py` overrides the dependency with a singleton, but nothing else does, so the uncached path is live in tests and in any app built without that override.
- Raises the climate-ref floor to 0.17.2, which is where `session_scope` and the `Reader` session argument land.

The dependency does not call `Database.close()`. The `Database` is shared, so disposing the engine after every response would tear down the pool the next request needs. `session_scope` closes the request session and returns its connection to the pool, which is all that is needed.

Adds tests covering the reuse of the `Database`, sessions being per request rather than shared, the session closing on teardown, and a real request leaving no connection checked out of the pool.